### PR TITLE
Allow slskd api key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@
 SLSKD_USERNAME=change-me
 SLSKD_PASSWORD=change-me
 
+# Optionally authenticate with an API key.
+SLSKD_API_KEY=
+
 # Navidrome credentials
 # Set NAVIDROME_USER/NAVIDROME_PASS after completing first-run Navidrome setup
 NAVIDROME_USER=admin

--- a/backend/config.py
+++ b/backend/config.py
@@ -3,6 +3,7 @@ from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     slskd_url: str = "http://slskd:5030"
+    slskd_api_key: str | None = None
     navidrome_url: str = "http://navidrome:4533"
     navidrome_user: str
     navidrome_pass: str

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -8,6 +8,10 @@ def get_http_client(request: Request) -> httpx.AsyncClient:
     return request.app.state.http_client
 
 
+def get_slskd_client(request: Request) -> httpx.AsyncClient:
+    return request.app.state.slskd_client
+
+
 def nd_params(**extra) -> dict:
     return {
         "u": settings.navidrome_user,

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,14 +6,23 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
+from config import settings
 from routers import discover, library, soulseek
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     app.state.http_client = httpx.AsyncClient()
+
+    slskd_headers = {}
+    if settings.slskd_api_key:
+        slskd_headers["X-API-Key"] = settings.slskd_api_key
+    app.state.slskd_client = httpx.AsyncClient(headers=slskd_headers)
+
     yield
+
     await app.state.http_client.aclose()
+    await app.state.slskd_client.aclose()
 
 
 app = FastAPI(lifespan=lifespan)

--- a/backend/routers/soulseek.py
+++ b/backend/routers/soulseek.py
@@ -7,11 +7,11 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from config import settings
-from dependencies import get_http_client
+from dependencies import get_slskd_client
 
 router = APIRouter(prefix="/api/soulseek")
 
-HttpClient = Annotated[httpx.AsyncClient, Depends(get_http_client)]
+HttpClient = Annotated[httpx.AsyncClient, Depends(get_slskd_client)]
 
 
 class SearchRequest(BaseModel):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -16,6 +16,7 @@ async def client():
     # ASGITransport doesn't trigger lifespan, so set up app.state manually
     async with httpx.AsyncClient() as http_client:
         app.state.http_client = http_client
+        app.state.slskd_client = http_client
         async with httpx.AsyncClient(
             transport=ASGITransport(app=app), base_url="http://test"
         ) as ac:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - NAVIDROME_PASS=${NAVIDROME_PASS}
       - NAVIDROME_URL=${NAVIDROME_URL:-http://navidrome:4533}
       - SLSKD_URL=${SLSKD_URL:-http://slskd:5030}
+      - SLSKD_API_KEY=${SLSKD_API_KEY:-}
       - LASTFM_API_KEY=${LASTFM_API_KEY:-}
     volumes:
       - ${MUSIC_DIR:-./music}:/music
@@ -22,7 +23,7 @@ services:
     container_name: slskd
     restart: unless-stopped
     environment:
-      - SLSKD_NO_AUTH=true          # local-only service, auth not needed
+      - SLSKD_NO_AUTH=true # local-only service, auth not needed (can remove this if using SLSKD_API_KEY)
       - SLSKD_DOWNLOADS_DIR=/music
       - SLSKD_SLSK_USERNAME=${SLSKD_USERNAME}
       - SLSKD_SLSK_PASSWORD=${SLSKD_PASSWORD}
@@ -30,8 +31,8 @@ services:
       - ${DATA_DIR:-./data}:/app
       - ${MUSIC_DIR:-./music}:/music
     ports:
-      - 5030:5030    # web UI (local network only)
-      - 50300:50300  # Soulseek peer port (optional: forward on router for better speeds)
+      - 5030:5030 # web UI (local network only)
+      - 50300:50300 # Soulseek peer port (optional: forward on router for better speeds)
 
   navidrome:
     image: deluan/navidrome:latest


### PR DESCRIPTION
Add the ability to connect to slskd with an API key.

This is useful if a user already has an existing slskd container running and doesn't use the one configured in the default docker-compose.yml in this repo.

## Verification
Ran this against my existing slskd container while setting the API key and was able to search from the front end.